### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ openai
 pandasai==0.2.2
 streamlit
 lux
-pandas-profiling
+ydata-profiling
 seaborn
 lux-api
 datapane


### PR DESCRIPTION
pandas-profiling has been deprecated and replaced with ydata-profiling. Running as is gives pydantic and pandas-profiling error. Please see package documentation for details.